### PR TITLE
Update elemtype.c

### DIFF
--- a/elemtype/int_vector/elemtype.c
+++ b/elemtype/int_vector/elemtype.c
@@ -31,9 +31,9 @@ void ElemDelete(ElemType *e) {
 }
 
 int ElemRead(FILE *f, ElemType *e) {
-    int ret = fscanf(f, "%u", &e->size);
+    int ret = fscanf(f, "%zu", &e->size);
     e->data = NULL;
-    if (ret != 1){
+    if (ret == 1){
         e->data = malloc(sizeof(int)*e->size);
         for (size_t i = 0; i < e->size; ++i) {
             if (!fscanf(f, "%i", &e->data[i])) { 


### PR DESCRIPTION
Cambiata la condizione per cui se ret è diverso da 1 allora viene eseguito il codice per leggere il vettore, il che è un problema perché nella corretta esecuzione del codice ret deve essere 1 e dunque tal codice non viene eseguito.